### PR TITLE
exec-path-from-shell README Clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ regardless of how complex the search framework is.
 
 ## Installation
 1. Clone or download this repository (path of the folder is the `<path-to-snails>` used below).
-2. Install [exec-path-from-shell](https://github.com/purcell/exec-path-from-shell) dependency.
+2. If you are using Mac, install [exec-path-from-shell](https://github.com/purcell/exec-path-from-shell) dependency.
 3. In your `~/.emacs`, add the following two lines:
 ```elisp
 (add-to-list 'load-path "<path-to-snails>") ; add snails to your load-path

--- a/snails-core.el
+++ b/snails-core.el
@@ -50,7 +50,7 @@
 ;; It's set in your ~/.emacs like this:
 ;; (add-to-list 'load-path (expand-file-name "~/elisp"))
 ;;
-;; Install exec-path-from-shell from https://github.com/purcell/exec-path-from-shell.
+;; If you are using Mac, install exec-path-from-shell from https://github.com/purcell/exec-path-from-shell.
 ;;
 ;; And the following to your ~/.emacs startup file.
 ;;


### PR DESCRIPTION
Due to this [commit](https://github.com/manateelazycat/snails/commit/748583223e812f19c8b14c2187c6e9c9204bc8c7), we don't need users from all platforms to install exec-path-from-shell