### PR TITLE
加了一行设置evil-emacs-state的代码

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -428,6 +428,8 @@ If `fuz' library has load, set with `check'.")
     (snails-mode)
     (if (fboundp 'evil-insert)
       (evil-insert 1))
+    (if (fboundp 'evil-emacs-state)
+        (evil-emacs-state))
     ;; Set input buffer face.
     (buffer-face-set 'snails-input-buffer-face)
     ;; Disable hl-line, header-line and mode-line in input buffer.


### PR DESCRIPTION
经过几天的使用，发现在snails-mode下，完全不需要使用evil模式，而且在evil模式下，部分快捷键如“ESC ESC ESC”和C-p都不能使用，需要按C-z切换为emac模式才能正常，也无法使用evil模式的hjkl进行移动。最终加代码使得强制为emacs模式。经过测试，snails窗口关闭后，对其他操作没有任何影响。类似于执行evil-insert，如果没有evil，不会有任何操作，有evil的话才会执行。