### PR TITLE
添加 snails-use-exec-path-from-shell 变量

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -174,7 +174,10 @@
 (require 'cl-lib)
 (require 'subr-x)
 
-(when (featurep 'cocoa)
+(defvar snails-use-exec-path-from-shell t)
+
+(when (and snails-use-exec-path-from-shell
+           (featurep 'cocoa))
   (require 'exec-path-from-shell)
   (exec-path-from-shell-initialize))
 


### PR DESCRIPTION
控制是否需要 (require 'exec-path-from-shell),  默认是 t