### PR TITLE
Windows中文搜索支持 & snails-backend-commands 没有获取所有命令

### DIFF
--- a/snails-backend-command.el
+++ b/snails-backend-command.el
@@ -94,7 +94,7 @@
 
 (add-hook 'after-init-hook 'snails-backend-command-get-commands)
 
-(run-with-idle-timer 3 nil 'snails-backend-command-get-commands)
+(run-with-idle-timer 2 nil 'snails-backend-command-get-commands)
 
 (run-with-idle-timer 60 t 'snails-backend-command-get-commands)
 

--- a/snails-backend-command.el
+++ b/snails-backend-command.el
@@ -92,7 +92,9 @@
     (mapatoms (lambda (s) (when (commandp s) (push (symbol-name s) cmds))))
     (setq snails-backend-command-list cmds)))
 
-(snails-backend-command-get-commands)
+(add-hook 'after-init-hook 'snails-backend-command-get-commands)
+
+(run-with-idle-timer 3 nil 'snails-backend-command-get-commands)
 
 (run-with-idle-timer 60 t 'snails-backend-command-get-commands)
 

--- a/snails-backend-fd.el
+++ b/snails-backend-fd.el
@@ -100,6 +100,10 @@
          (setq search-dir (first search-info))
          (setq search-input (second search-info)))
 
+       (when (memq system-type '(cygwin windows-nt ms-dos))
+         (setq search-input (encode-coding-string search-input 'gbk))
+         (setq search-dir (encode-coding-string search-dir 'gbk)))
+
        (list "fd" "-c" "never" "-a" "-tf" search-input "--search-path" search-dir))
      ))
 

--- a/snails-backend-fd.el
+++ b/snails-backend-fd.el
@@ -101,8 +101,8 @@
          (setq search-input (second search-info)))
 
        (when (memq system-type '(cygwin windows-nt ms-dos))
-         (setq search-input (encode-coding-string search-input 'gbk))
-         (setq search-dir (encode-coding-string search-dir 'gbk)))
+         (setq search-input (encode-coding-string search-input locale-coding-system))
+         (setq search-dir (encode-coding-string search-dir locale-coding-system)))
 
        (list "fd" "-c" "never" "-a" "-tf" search-input "--search-path" search-dir))
      ))

--- a/snails-backend-rg.el
+++ b/snails-backend-rg.el
@@ -101,8 +101,8 @@
          (setq search-input (second search-info)))
 
        (when (memq system-type '(cygwin windows-nt ms-dos))
-         (setq search-input (encode-coding-string search-input 'gbk))
-         (setq search-dir (encode-coding-string search-dir 'gbk)))
+         (setq search-input (encode-coding-string search-input locale-coding-system))
+         (setq search-dir (encode-coding-string search-dir locale-coding-system)))
 
        ;; Search.
        (when search-dir

--- a/snails-backend-rg.el
+++ b/snails-backend-rg.el
@@ -100,6 +100,10 @@
          (setq search-dir (first search-info))
          (setq search-input (second search-info)))
 
+       (when (memq system-type '(cygwin windows-nt ms-dos))
+         (setq search-input (encode-coding-string search-input 'gbk))
+         (setq search-dir (encode-coding-string search-dir 'gbk)))
+
        ;; Search.
        (when search-dir
          (list "rg" "--no-heading" "--column" "--color" "never" "--max-columns" "300" search-input search-dir)


### PR DESCRIPTION
1. 让 rg 和 fd 在windows 支持中文
2.  snails-backend-commands 只在require时 get commands 会导致在snails之后 require的插件和延迟 1s 加载的插件的命令没办法在 emacs 启动后收集到。