### PR TITLE
change rule of register backends and prefix

### DIFF
--- a/snails-backend-command.el
+++ b/snails-backend-command.el
@@ -111,6 +111,9 @@
  :name
  "COMMAND"
 
+ :prefix
+ ">"
+
  :candidate-filter
  (lambda (input)
    (let (candidates)

--- a/snails-backend-current-buffer.el
+++ b/snails-backend-current-buffer.el
@@ -88,6 +88,9 @@
  :name
  "CURRENT BUFFER"
 
+ :prefix
+ "#"
+
  :build-command
  (lambda (input)
    (let ((buffer-filename (buffer-file-name snails-start-buffer)))

--- a/snails-backend-everything.el
+++ b/snails-backend-everything.el
@@ -79,6 +79,9 @@
  :name
  "EVERYTHING"
 
+ :prefix
+ "?"
+
  :build-command
  (lambda (input)
    (when (and (executable-find "es")

--- a/snails-backend-fd.el
+++ b/snails-backend-fd.el
@@ -88,6 +88,9 @@
  :name
  "FD"
 
+ :prefix
+ "?"
+
  :build-command
  (lambda (input)
    (when (and (executable-find "fd")

--- a/snails-backend-imenu.el
+++ b/snails-backend-imenu.el
@@ -135,6 +135,9 @@
  :name
  "IMENU"
 
+ :prefix
+ "@"
+
  :candidate-filter
  (lambda (input)
    (let ((imenu-items (snails-backend-imenu-candidates snails-start-buffer))

--- a/snails-backend-mdfind.el
+++ b/snails-backend-mdfind.el
@@ -88,6 +88,9 @@
  :name
  "MDFIND"
 
+ :prefix
+ "?"
+
  :build-command
  (lambda (input)
    (when (and (featurep 'cocoa)

--- a/snails-backend-projectile.el
+++ b/snails-backend-projectile.el
@@ -100,6 +100,9 @@
  :name
  "PROJECTILE"
 
+ :prefix
+ "?"
+
  :candidate-filter
  (lambda (input)
    (let ((candidates)

--- a/snails-backend-rg.el
+++ b/snails-backend-rg.el
@@ -88,6 +88,9 @@
  :name
  "RG"
 
+ :prefix
+ "!"
+
  :build-command
  (lambda (input)
    (when (and (executable-find "rg")

--- a/snails-core.el
+++ b/snails-core.el
@@ -1392,6 +1392,7 @@ Otherwise return nil."
              '(("name" . ,name)
                ("search" . ,search-function)
                ("icon" . ,candidate-icon)
+               ("prefix" . ,prefix)
                ("do" . ,candidate-do)
                )
              )
@@ -1406,7 +1407,7 @@ Otherwise return nil."
          (let* ((prefix ,prefix)
                 (backends-with-prefix (list ',backend-name)))
            ;; add new backends to old prefix/backends pair
-           (dolist (each-prefix (cadr (cadr ',old-prefix)))
+           (dolist (each-prefix (cadadr ',old-prefix))
              (push each-prefix backends-with-prefix))
            (setq backends-with-prefix `(,prefix ',backends-with-prefix))
 
@@ -1452,6 +1453,7 @@ Otherwise return nil."
              '(("name" . ,name)
                ("search" . ,search-function)
                ("icon" . ,candidate-icon)
+               ("prefix" . ,prefix)
                ("do" . ,candidate-do)
                )
              )
@@ -1466,7 +1468,7 @@ Otherwise return nil."
          (let* ((prefix ,prefix)
                 (backends-with-prefix (list ',backend-name)))
            ;; add new backends to old prefix/backends pair
-           (dolist (each-prefix (cadr (cadr ',old-prefix)))
+           (dolist (each-prefix (cadadr ',old-prefix))
              (push each-prefix backends-with-prefix))
            (setq backends-with-prefix `(,prefix ',backends-with-prefix))
 

--- a/snails-core.el
+++ b/snails-core.el
@@ -385,7 +385,8 @@ or set it with any string you want."
 
         ;; Set `snails-search-backends' if argument backends is set.
         (when (and (listp backends)
-                   (> (length backends) 0))
+                   (> (length backends) 0)
+                   (cl-subsetp backends snails-default-backends))
           (setq snails-search-backends backends))
 
         ;; Record buffer before start snails.


### PR DESCRIPTION
Add  register backends and prefix code in macro, register backend when load plugin file.
so we can load snails-core.el without load other plugin file. 