### PR TITLE
fix: ignore running timer error message: (beginning-of-buffer)

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -988,7 +988,7 @@ influence of C1 on the result."
   ;; Adjust line if reach bottom line.
   (when (and (eobp)
              (snails-empty-line-p))
-    (previous-line 2)))
+    (ignore-errors (previous-line 2))))
 
 (defun snails-jump-to-previous-item ()
   "Select previous candidate item."


### PR DESCRIPTION
When there is nothing in content buffer, (previous-line 2) will
signals an error. It cause function `run-with-timer' show many
error message like below.

Error running timer ‘snails-render-bufer’: (beginning-of-buffer)