### PR TITLE
Fixed #48

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -542,8 +542,9 @@ or set it with any string you want."
 
 (defun snails-focus-init-frame ()
   (when snails-init-frame
-    (select-frame snails-init-frame)
-    ))
+    (select-frame snails-init-frame))
+  (when (frame-focus-state snails-init-frame)
+    (select-frame-set-input-focus snails-init-frame)))
 
 (defun snails-create-input-buffer ()
   "Create input buffer."


### PR DESCRIPTION
On macOS, even if `select-frame` is used, snails-frame is still on the top of other frames.  Thus, we also have to set the input focus to the init frame.

Due to the `focus-out-hook`, I add a when-condition to avoid setting the input focus again.

I'm not sure if this is the best way to solve the issue.  It's the reversed one of #1 -- Other frames are obscured by snails frame on macOS.