### PR TITLE
Update snails-backend-mdfind.el

### DIFF
--- a/snails-backend-mdfind.el
+++ b/snails-backend-mdfind.el
@@ -92,7 +92,7 @@
  (lambda (input)
    (when (and (featurep 'cocoa)
               (> (length input) 3))
-     (list "mdfind" "-name" (format "'%s'" input))))
+     (list "mdfind" "-name" (format "%s" input))))
 
  :candidate-filter
  (lambda (candidate-list)


### PR DESCRIPTION
Remove apostrophe from "(list "mdfind" "-name" (format "'%s'" input))))" to fix mdfind command.