### PR TITLE
feat: Add frame name option for snails

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -306,6 +306,9 @@ need to set face attribute, such as foreground and background.")
 (defvar snails-init-frame nil
   "The frame before snails start, use for focus after snails hide.")
 
+(defvar snails-frame-name "emacs-snails"
+  "The frame name of snails created.")
+
 (defvar snails-input-buffer " *snails input*"
   "The buffer name of search input buffer.")
 
@@ -751,7 +754,8 @@ or set it with any string you want."
              (frame-visible-p snails-frame))
       (setq snails-frame
             (make-frame
-             '((parent-frame . snails-init-frame)
+             '((name . snails-frame-name)
+               (parent-frame . snails-init-frame)
                (skip-taskbar . t)
                (minibuffer . nil)
                (visibility . nil)


### PR DESCRIPTION
add new var `snails-frame-name'

change `snails-create-popup-window'

希望通过添加 snails 创建frame时的初始name，dwm等平铺管理器能够正常 float snails 的frame

原始的 frame 创建后信息如下

```
title: GNU Emacs at `YOUR_PCNAME`
class: Emacs-29.0.50
instance: emacs-29-0-50
```

通过修改 make-frame 的创建参数修改 name 为 `snails-frame-name`

修改后

```
title: emacs-snails
class: Emacs-29.0.50
instance: emacs-29-0-50
```