### PR TITLE
fix: make-frame with snials-frame-name need backquote

### DIFF
--- a/snails-core.el
+++ b/snails-core.el
@@ -758,7 +758,7 @@ or set it with any string you want."
              (frame-visible-p snails-frame))
       (setq snails-frame
             (make-frame
-             '((name . snails-frame-name)
+             `((name . ,snails-frame-name)
                (parent-frame . snails-init-frame)
                (skip-taskbar . t)
                (minibuffer . nil)


### PR DESCRIPTION
without backquote will got a error
(error "Invalid frame name--not a string or nil")

不知道直接对整个 make-frame 参数直接backquote 是否合理，目前经过测试可以正常运行snails的emacs版本如下
```
GNU Emacs 29.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.33, cairo version 1.17.6) of 2022-04-19
GNU Emacs 28.1.90 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.34, cairo version 1.17.6) of 2022-07-05
```
