### PR TITLE
add max-result limitation to everything backend

### DIFF
--- a/snails-backend-everything.el
+++ b/snails-backend-everything.el
@@ -83,7 +83,7 @@
  (lambda (input)
    (when (and (executable-find "es")
               (> (length input) 3))
-     (list "es" input)))
+     (list "es" "-n" "30" input)))
 
  :candidate-filter
  (lambda (candidate-list)


### PR DESCRIPTION
# Description

Currently, everything could send thousands of results to snails. That's the reason why it sometimes in lag or blocking.

My purpose is that add "-n 30" as argument to "es" to limit the max number of results.

