### PR TITLE
feat: let snails-backend-everything support path separator like other backends

### DIFF
--- a/snails-backend-everything.el
+++ b/snails-backend-everything.el
@@ -86,9 +86,9 @@
  (lambda (input)
    (when (and (executable-find "es")
               (> (length input) 3))
-     (let ((search-dir nil)
-           (search-input input)
-           (search-info (snails-pick-search-info-from-input input)))
+     (let (search-dir
+          (search-input input)
+          (search-info (snails-pick-search-info-from-input input)))
 
        (when search-info
          (setq search-dir (cl-first search-info))

--- a/snails-backend-everything.el
+++ b/snails-backend-everything.el
@@ -56,6 +56,9 @@
 
 ;;; Change log:
 ;;
+;; 2022/07/12
+;;      * Support path separator.
+;;
 ;; 2019/07/31
 ;;      * First released.
 ;;
@@ -83,7 +86,25 @@
  (lambda (input)
    (when (and (executable-find "es")
               (> (length input) 3))
-     (list "es" "-n" "30" input)))
+     (let ((search-dir nil)
+           (search-input input)
+           (search-info (snails-pick-search-info-from-input input)))
+
+       (when search-info
+         (setq search-dir (cl-first search-info))
+         (setq search-input (cl-second search-info)))
+
+       (when (and search-info
+              (memq system-type '(cygwin windows-nt ms-dos)))
+         (setq search-input (encode-coding-string search-input locale-coding-system))
+         (setq search-dir (encode-coding-string search-dir locale-coding-system)))
+
+       ;; If the user input character includes the path separator @, replace the current directory with the entered directory.
+       (cond (search-dir (list "es"
+                     "-n" "30"
+                     "-path" search-dir
+                     search-input))
+             (t (list "es" "-n" "30" input))))))
 
  :candidate-filter
  (lambda (candidate-list)


### PR DESCRIPTION
# Description
Currently, snails-backend-everyting is the only file search backend that not support "@" as the path sepatator.
Besides the feature leakage, there also a return nothing issue while user input "@".

# Purpose
Complete this lacking feature.

# What dose this PR do
Honestly, I'm not familiar emacs lisp. I read and copy the code in snails-backend-rg for this implement.

At last, please spent a little more time for this code review caused my poor knowlage in eamcs lisp.

Really thanks for your work. :)